### PR TITLE
magselect: add scevent plugin for rule-based preferred magnitude selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Geoscience Australia.
   different prefilters.
 - **eqnamer** is an scevent plugin that applies NEAC-specific logic to set the region
   name of earthquakes.
+- **magselect** is an scevent plugin that selects the preferred magnitude type for each
+  event based on ordered, configurable rules evaluated against a reference magnitude.
 
 
 ## Building

--- a/plugins/events/CMakeLists.txt
+++ b/plugins/events/CMakeLists.txt
@@ -1,1 +1,2 @@
 SUBDIRS(eqnamer)
+SUBDIRS(magselect)

--- a/plugins/events/magselect/CMakeLists.txt
+++ b/plugins/events/magselect/CMakeLists.txt
@@ -1,0 +1,11 @@
+SET(PLUGIN_TARGET magselect)
+SET(PLUGIN_SOURCES selector.cpp)
+
+INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/src/base/main/apps/processing/scevent)
+INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/src/base/main/apps/processing/scevent)
+
+SC_ADD_PLUGIN_LIBRARY(PLUGIN ${PLUGIN_TARGET} scevent)
+SC_LINK_LIBRARIES_INTERNAL(${PLUGIN_TARGET} evplugin)
+
+FILE(GLOB descs "${CMAKE_CURRENT_SOURCE_DIR}/descriptions/*.xml")
+INSTALL(FILES ${descs} DESTINATION ${SC3_PACKAGE_APP_DESC_DIR})

--- a/plugins/events/magselect/README.md
+++ b/plugins/events/magselect/README.md
@@ -1,0 +1,75 @@
+# magselect
+
+**magselect** is an scevent plugin that selects the preferred magnitude type for each
+event based on ordered, configurable rules. Each rule pairs a logical expression with a
+target magnitude type. Rules are evaluated top-to-bottom against a reference magnitude;
+the first matching rule wins. If no rule matches, scevent falls back to its standard
+`eventAssociation.magTypes` priority list.
+
+## Requirements
+
+SeisComP ≥ 7.3.0 (SC API ≥ 17.3.0). The plugin uses LeParser V2
+(`Seiscomp::Utils::V2`) which was introduced in that release. It will not
+compile against earlier versions.
+
+## How it works
+
+At event processing time the plugin:
+
+1. Looks up the configured reference magnitude type on the preferred origin.
+2. Evaluates each rule's condition using the reference magnitude's value and station
+   count (plus origin depth and location if needed).
+3. Returns the first magnitude on the origin whose type matches a passing rule.
+4. Returns `nullptr` if no rule matches, letting scevent handle magnitude selection
+   through its normal priority mechanism.
+
+## Condition keys
+
+| Key | Description |
+|---|---|
+| `mag` / `magnitude` | Value of the reference magnitude |
+| `stations` | Station count of the reference magnitude |
+| `depth` | Origin depth (km) |
+| `lat` / `latitude` | Origin latitude |
+| `lon` / `longitude` | Origin longitude |
+
+Logical operators (LeParser V2 syntax): `&&` (and), `||` (or), `!` (not).
+Comparison operators: `<`, `<=`, `>`, `>=`, `==`, `!=`.
+
+## Configuration
+
+Add `magselect` to the plugins list and configure rules in `scevent.cfg`:
+
+```
+plugins = ${plugins}, magselect
+
+# Magnitude type used to resolve 'mag' and 'stations' in rule conditions.
+# Must be present on the origin. Required.
+magselect.referenceType = MLa
+
+# Ordered list of rule names (evaluated top-to-bottom, first match wins).
+magselect.rules = large, medium, small, fallback
+
+magselect.rules.large.condition = "mag >= 6.0 && stations >= 3"
+magselect.rules.large.magnitudeType = MLa01
+
+magselect.rules.medium.condition = "mag >= 4.0 && stations >= 3"
+magselect.rules.medium.magnitudeType = MLa05
+
+magselect.rules.small.condition = "mag < 4.0 && stations >= 3"
+magselect.rules.small.magnitudeType = MLa075
+
+# Catches events where mag is unavailable but station count is met.
+magselect.rules.fallback.condition = "stations >= 3"
+magselect.rules.fallback.magnitudeType = MLa075
+```
+
+### Notes
+
+- `magselect.referenceType` is required. The plugin will refuse to start if it is
+  missing from the configuration.
+- The reference type should be an unfiltered (or lightly filtered) magnitude so that
+  threshold comparisons are not biased by high-pass filter attenuation at larger
+  magnitudes.
+- Rules whose target magnitude type is not present on the origin are skipped with a
+  warning, and evaluation continues to the next rule.

--- a/plugins/events/magselect/descriptions/global_magselect.xml
+++ b/plugins/events/magselect/descriptions/global_magselect.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<seiscomp>
+    <plugin name="magselect">
+        <extends>scevent</extends>
+        <description>
+            Selects the preferred magnitude type for each event based on
+            ordered, configurable rules. Each rule pairs a logical expression
+            (evaluated against the reference magnitude type) with a target
+            magnitude type. The first matching rule wins. If no rule matches,
+            scevent falls back to its standard magTypes priority list.
+
+            Available condition keys:
+              mag / magnitude  — value of the reference magnitude
+              stations         — station count of the reference magnitude
+              depth            — origin depth (km)
+              lat / latitude   — origin latitude
+              lon / longitude  — origin longitude
+
+            Operators: &lt; &lt;= &gt; &gt;= == != and (&amp;&amp;) or (||) not (!)
+
+            Example configuration in scevent.cfg:
+              magselect.referenceType = MLa
+              magselect.rules = large, medium, small, fallback
+              magselect.rules.large.condition = "mag >= 6.0 &amp;&amp; stations >= 3"
+              magselect.rules.large.magnitudeType = MLa01
+              magselect.rules.medium.condition = "mag >= 4.0 &amp;&amp; stations >= 3"
+              magselect.rules.medium.magnitudeType = MLa05
+              magselect.rules.small.condition = "mag &lt; 4.0 &amp;&amp; stations >= 3"
+              magselect.rules.small.magnitudeType = MLa075
+              magselect.rules.fallback.condition = "stations >= 3"
+              magselect.rules.fallback.magnitudeType = MLa075
+        </description>
+        <configuration>
+            <group name="magselect">
+                <parameter name="referenceType" type="string">
+                    <description>
+                        Magnitude type used to resolve the 'mag' and 'stations'
+                        keys in rule conditions. Must be present on the origin.
+                        Required — the plugin will not start without this parameter.
+                    </description>
+                </parameter>
+                <parameter name="rules" type="list:string">
+                    <description>
+                        Ordered list of rule names. Rules are evaluated top-to-bottom;
+                        the first matching rule wins. Each rule name N requires:
+                          magselect.rules.N.condition    — LeParser V2 logical expression
+                          magselect.rules.N.magnitudeType — magnitude type to select
+                    </description>
+                </parameter>
+            </group>
+        </configuration>
+    </plugin>
+</seiscomp>

--- a/plugins/events/magselect/selector.cpp
+++ b/plugins/events/magselect/selector.cpp
@@ -1,0 +1,225 @@
+#define SEISCOMP_COMPONENT MAGSELECT
+
+#include <seiscomp/core/version.h>
+#if SC_API_VERSION < SC_API_VERSION_CHECK(17, 3, 0)
+#  error "magselect requires SeisComP API >= 17.3.0 (SeisComP release >= 7.3.0)"
+#endif
+
+#include <seiscomp/core/exceptions.h>
+#include <seiscomp/core/plugin.h>
+#include <seiscomp/config/config.h>
+#include <seiscomp/datamodel/event.h>
+#include <seiscomp/datamodel/magnitude.h>
+#include <seiscomp/datamodel/origin.h>
+#include <seiscomp/logging/log.h>
+#include <seiscomp/plugins/events/eventprocessor.h>
+#include <seiscomp/utils/leparser.h>
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+ADD_SC_PLUGIN(
+    "Rule-based preferred magnitude type selector for scevent.",
+    "Geoscience Australia", 0, 1, 0)
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+namespace {
+
+/*
+ * Evaluation context that exposes origin and reference-magnitude attributes
+ * to LeParser V2 conditions.
+ *
+ * Available keys (double):
+ *   mag / magnitude  — value of the reference magnitude type
+ *   stations         — station count of the reference magnitude type
+ *   depth            — origin depth in km
+ *   lat / latitude   — origin latitude
+ *   lon / longitude  — origin longitude
+ *
+ * Throws Core::ValueException when a key is valid but has no value set.
+ * Throws std::runtime_error for unknown keys.
+ */
+class MagKeyValueContext : public Seiscomp::Utils::V2::LeKeyValueContext {
+    public:
+        MagKeyValueContext(const Seiscomp::DataModel::Origin *origin,
+                           const std::string &referenceType)
+            : _origin(origin), _refMag(nullptr) {
+            for ( size_t i = 0; i < origin->magnitudeCount(); ++i ) {
+                auto *m = origin->magnitude(i);
+                if ( m->type() == referenceType ) {
+                    _refMag = m;
+                    break;
+                }
+            }
+        }
+
+        double getDouble(std::string_view key) const override {
+            if ( key == "mag" || key == "magnitude" ) {
+                if ( !_refMag ) throw Seiscomp::Core::ValueException();
+                return _refMag->magnitude().value();
+            }
+            if ( key == "stations" ) {
+                if ( !_refMag ) throw Seiscomp::Core::ValueException();
+                if ( !_refMag->stationCount() ) throw Seiscomp::Core::ValueException();
+                return static_cast<double>(*_refMag->stationCount());
+            }
+            if ( key == "depth" ) {
+                return _origin->depth().value();
+            }
+            if ( key == "lat" || key == "latitude" ) {
+                return _origin->latitude().value();
+            }
+            if ( key == "lon" || key == "longitude" ) {
+                return _origin->longitude().value();
+            }
+            throw std::runtime_error(std::string("unknown key: ") + std::string(key));
+        }
+
+        std::string getString(std::string_view key) const override {
+            throw std::runtime_error(std::string("unknown key: ") + std::string(key));
+        }
+
+    private:
+        const Seiscomp::DataModel::Origin    *_origin;
+        const Seiscomp::DataModel::Magnitude *_refMag;
+};
+
+} // namespace
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+class MagSelectProcessor : public Seiscomp::Client::EventProcessor {
+
+    struct SelectorRule {
+        Seiscomp::Utils::V2::LeExpressionPtr expression;
+        std::string                           magnitudeType;
+    };
+
+    public:
+
+        bool setup(const Seiscomp::Config::Config &config) override {
+            try {
+                _referenceType = config.getString("magselect.referenceType");
+            }
+            catch ( ... ) {
+                SEISCOMP_ERROR("magselect: magselect.referenceType is not configured");
+                return false;
+            }
+
+            std::vector<std::string> ruleNames;
+            try {
+                ruleNames = config.getStrings("magselect.rules");
+            }
+            catch ( ... ) {
+                SEISCOMP_ERROR("magselect: magselect.rules is not configured");
+                return false;
+            }
+
+            Seiscomp::Utils::V2::LeKeyValueFactory factory;
+            auto symbols = Seiscomp::Utils::V2::LeParser::DefaultSymbols();
+            symbols.reserved = Seiscomp::Utils::V2::LeKeyValueFactory::Reserved();
+            Seiscomp::Utils::V2::LeParser parser(&factory, &symbols);
+
+            for ( const auto &name : ruleNames ) {
+                const std::string base = "magselect.rules." + name;
+
+                std::string condStr;
+                try {
+                    condStr = config.getString(base + ".condition");
+                }
+                catch ( ... ) {
+                    SEISCOMP_WARNING("magselect: rule '%s' has no condition, skipping",
+                                     name.c_str());
+                    continue;
+                }
+
+                std::string magType;
+                try {
+                    magType = config.getString(base + ".magnitudeType");
+                }
+                catch ( ... ) {
+                    SEISCOMP_WARNING("magselect: rule '%s' has no magnitudeType, skipping",
+                                     name.c_str());
+                    continue;
+                }
+
+                Seiscomp::Utils::V2::LeExpression *expr = nullptr;
+                try {
+                    expr = parser.parse(condStr);
+                }
+                catch ( const std::exception &e ) {
+                    SEISCOMP_WARNING("magselect: rule '%s' invalid condition '%s': %s",
+                                     name.c_str(), condStr.c_str(), e.what());
+                    continue;
+                }
+
+                SelectorRule rule;
+                rule.expression = expr;
+                rule.magnitudeType = magType;
+                _rules.emplace_back(std::move(rule));
+
+                SEISCOMP_INFO("magselect: rule '%s': [%s] -> %s",
+                              name.c_str(), condStr.c_str(), magType.c_str());
+            }
+
+            SEISCOMP_INFO("magselect: %d rule(s) loaded, reference type: %s",
+                          static_cast<int>(_rules.size()), _referenceType.c_str());
+            return !_rules.empty();
+        }
+
+        /*
+         * Walks the rule list in order. Builds an evaluation context from the
+         * origin using _referenceType as the source for 'mag' and 'stations'.
+         * Returns the first Magnitude on the origin whose type matches a
+         * passing rule, or nullptr to let scevent fall back to its magTypes
+         * priority list.
+         */
+        Seiscomp::DataModel::Magnitude *preferredMagnitude(
+                const Seiscomp::DataModel::Origin *origin) override {
+            if ( _rules.empty() || !origin ) return nullptr;
+
+            MagKeyValueContext ctx(origin, _referenceType);
+
+            for ( const auto &rule : _rules ) {
+                if ( !rule.expression ) continue;
+
+                try {
+                    if ( !rule.expression->eval(&ctx) ) continue;
+                }
+                catch ( ... ) {
+                    continue;
+                }
+
+                for ( size_t i = 0; i < origin->magnitudeCount(); ++i ) {
+                    auto *mag = origin->magnitude(i);
+                    if ( mag->type() == rule.magnitudeType ) {
+                        SEISCOMP_DEBUG("magselect: selected %s for origin %s",
+                                       rule.magnitudeType.c_str(),
+                                       origin->publicID().c_str());
+                        return mag;
+                    }
+                }
+
+                SEISCOMP_WARNING(
+                    "magselect: rule matched but type '%s' not found on origin %s — "
+                    "trying next rule",
+                    rule.magnitudeType.c_str(), origin->publicID().c_str());
+            }
+
+            return nullptr;
+        }
+
+        bool process(Seiscomp::DataModel::Event *, bool,
+                     const Journal &) override {
+            return false;
+        }
+
+    private:
+        std::string               _referenceType;
+        std::vector<SelectorRule> _rules;
+};
+
+REGISTER_EVENTPROCESSOR(MagSelectProcessor, "MagSelect");
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<


### PR DESCRIPTION
## Summary

- Adds `magselect`, an `scevent` `EventProcessor` plugin that selects the preferred magnitude type for each event using ordered, configurable rules
- Each rule pairs a LeParser V2 logical expression with a target magnitude type; first matching rule wins; falls back to scevent's `eventAssociation.magTypes` if no rule matches
- Condition keys: `mag`/`magnitude`, `stations`, `depth`, `lat`/`latitude`, `lon`/`longitude`
- **Requires SeisComP ≥ 7.3.0** (SC API ≥ 17.3.0) — LeParser V2 was introduced in that release; compile-time `#error` guard enforces this

## Motivation

GA operates four MLa variants (`MLa`, `MLa01`, `MLa05`, `MLa075`) with different Butterworth high-pass pre-filters. The preferred variant depends on event magnitude and this plugin selects the appropriate variant automatically at scevent time, after all magnitudes have been computed by scmag.